### PR TITLE
throw an error for non https api urls

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -3,6 +3,7 @@ const CUtils = require('./utils/common-utils')
 
 const ASSETS_PREF = '/api';
 const EDITOR_PREF = '/editor';
+const HTTPS_PREF_REG = /^https:\/\//;
 
 class ApiClient {
   constructor(baseUrl, apiKey) {
@@ -46,7 +47,7 @@ class ApiClient {
     url = this.fullUrl(url, pref);
 
     if (addToken) {
-      url = `${url}?access_token=${this.apiKey}`; // ok with https
+      url = this.checkAndAddAuth(url);
     }
 
     return request({
@@ -108,6 +109,12 @@ class ApiClient {
     const resp = await this.methodGet(url, EDITOR_PREF, true);
 
     return JSON.parse(resp);
+  }
+
+  checkAndAddAuth (url) {
+    return HTTPS_PREF_REG.test(url) ?
+        `${url}?access_token=${this.apiKey}` :
+        CUtils.throwFatalError(`Non-https url specified: ${url}`);
   }
 }
 

--- a/src/utils/get-config.js
+++ b/src/utils/get-config.js
@@ -59,6 +59,8 @@ class GetConfig {
       return h.id;
 
     } catch (e) {
+      console.log(e.message);
+
       CUtils.throwFatalError('Failed to retrieve your current PlayCanvas branch. Use your personal api token');
     }
   }


### PR DESCRIPTION
As per Winston's request on playcanvas-sync security review (https://jira.sc-corp.net/browse/REV-7684), I'm adding code that will throw an error if a non-https url is 
used to connect to PlayCanvas api.