### PR TITLE
Readme on target dir var, minor edits for the new 'yes' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ All listed key-value pairs are necessary. You can keep
 some of them in `.pcconfig` in your home directory,
 and others in `pcconfig.json` in your project.
 
+To find `pcconfig.json`, `pcsync` needs to know your target directory,
+so `PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable.
+
 Backslash characters should be written as `\\` (escaped).
 
 # Files and Folders to Exclude

--- a/README.md
+++ b/README.md
@@ -53,12 +53,8 @@ switch to the browser code editor.
   parseIgnore                 list assets matched by pcignore.txt
 ```
 
-To automatically answer "yes" to any prompts that might print
-on the command line from `pushAll` or `pullAll` commands, simply supply `-y` or `--yes` arguments:
-
-```
-pcsync pushAll -y
-```
+`pushAll` and `pullAll` accept an optional `-y` or `--yes` flag to
+automatically answer "yes" to confirmation prompts.
 
 A local directory [designated](#config-variables) as `PLAYCANVAS_TARGET_DIR`
 corresponds to the root of the PlayCanvas file and folder asset hierarchy.

--- a/README.md
+++ b/README.md
@@ -238,12 +238,9 @@ Version Control Panel of the PlayCanvas Editor, and
 your project id from its home page url, e.g.
 for `playcanvas.com/project/10/overview/test_proj` the id is 10.
 
-All listed key-value pairs are necessary. You can keep 
-some of them in `.pcconfig` in your home directory,
-and others in `pcconfig.json` in your project.
-
-To find `pcconfig.json`, `pcsync` needs to know your target directory,
-so `PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable.
+All listed key-value pairs are necessary. You can split them between
+`.pcconfig` (in your home directory), `pcconfig.json` (in your project target directory),
+and environment variables. `PLAYCANVAS_TARGET_DIR` cannot be set in `pcconfig.json`.
 
 Backslash characters should be written as `\\` (escaped).
 

--- a/pcsync.js
+++ b/pcsync.js
@@ -78,21 +78,21 @@ function runDiff (filePath) {
 function runOverwriteAllLocal (cmdObj) {
     CUtils.handleForceRegOpts(cmdObj);
 
-    if(cmdObj.yes) return new OverwriteAllLocalWithRemote().run();
-
-    SyncUtils.compareAndPrompt(() => {
+    const cb = function () {
         return new OverwriteAllLocalWithRemote().run();
-    });
+    };
+
+    return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
 }
 
 function runOverwriteAllRemote (cmdObj) {
     CUtils.handleForceRegOpts(cmdObj);
 
-    if(cmdObj.yes) return new OverwriteAllRemoteWithLocal().run();
-
-    SyncUtils.compareAndPrompt(() => {
+    const cb = function () {
         return new OverwriteAllRemoteWithLocal().run();
-    });
+    };
+
+    return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
 }
 
 function runDownloadSingle (filePath) {


### PR DESCRIPTION
Added to readme that the target dir var can only be set in .pcconfig or an env var, but not in pcconfig.json (which itself cannot be found without knowing the target dir). This should likely resolve https://github.com/playcanvas/playcanvas-sync/issues/20
Minor readme and code edits for the new "yes" flag for push/pullAll