### PR TITLE
Allow PlayCanvas-Sync to Run without `.pcconfig` file

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -108,7 +108,6 @@ class ApiClient {
     const url = `/project/${projectId}/branch`;
 
     const resp = await this.methodGet(url, EDITOR_PREF, true);
-    console.log('GET RESPONSE:', resp);
 
     return JSON.parse(resp);
   }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -108,6 +108,7 @@ class ApiClient {
     const url = `/project/${projectId}/branch`;
 
     const resp = await this.methodGet(url, EDITOR_PREF, true);
+    console.log('GET RESPONSE:', resp);
 
     return JSON.parse(resp);
   }

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -26,7 +26,8 @@ const optionalFields = [
 const allConfigFields = requiredFields.concat(optionalFields);
 
 const fieldsWithDefaults = {
-    PLAYCANVAS_BASE_URL: 'https://playcanvas.com'
+    PLAYCANVAS_BASE_URL: 'https://playcanvas.com',
+    PLAYCANVAS_TARGET_DIR: './'
 };
 
 const integerFields = [
@@ -62,11 +63,11 @@ class ConfigVars {
 
         this.fromConfigFile(os.homedir(), HOME_CONFIG_FILE);
 
-        await this.checkPrepTarg();
-
         this.fromConfigFile(this.result.PLAYCANVAS_TARGET_DIR, TARGET_CONFIG_FILE);
 
         this.fromDefaults();
+
+        await this.checkPrepTarg();
 
         requiredFields.forEach(this.checkRequired, this);
     }


### PR DESCRIPTION
### Motivation

I was attempting to run this code for the first time in a while on my machine and I was getting a `Error: could not find target directory: . Check capitalization.` error. It looks like the code expects a `PLAYCANVAS_TARGET_DIR` from the `.pcconfig` file. So, that makes adding a `.pcconfig` with a `PLAYCANVS_TARGET_DIR` a requirement for new users. From the language in the README, I had the impression that the `.pcconfig` was optional.

### What's Changed

This PR adds a default to `PLAYCANVAS_TARGET_DIR` to use the CWD. That default only comes into play when `PLAYCANVAS_TARGET_DIR` is not set. Also, when the target dir was validated was moved down to be after defaults are set.

### Tested on

:heavy_check_mark: Ubuntu 20.04
:heavy_check_mark: Windows 11 (Git Bash)
:construction: TODO - OS X

### Fixes

Partially fixes #22 