### PR TITLE
Allow the current working dir as target dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,15 @@ Version Control Panel of the PlayCanvas Editor, and
 your project id from its home page url, e.g.
 for `playcanvas.com/project/10/overview/test_proj` the id is 10.
 
+Backslash characters should be written as `\\` (escaped).
+
 All listed key-value pairs are necessary. You can split them between
 `.pcconfig` (in your home directory), `pcconfig.json` (in your project target directory),
-and environment variables. `PLAYCANVAS_TARGET_DIR` cannot be set in `pcconfig.json`.
+and environment variables.
 
-Backslash characters should be written as `\\` (escaped).
+`PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable. You
+can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use
+your current working directory as your target.
 
 # Files and Folders to Exclude
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,6 @@ Version Control Panel of the PlayCanvas Editor, and
 your project id from its home page url, e.g.
 for `playcanvas.com/project/10/overview/test_proj` the id is 10.
 
-Backslash characters should be written as `\\` (escaped).
-
 All listed key-value pairs are necessary. You can split them between
 `.pcconfig` (in your home directory), `pcconfig.json` (in your project target directory),
 and environment variables.
@@ -247,6 +245,8 @@ and environment variables.
 `PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable. You
 can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use
 your current working directory as your target.
+
+Backslash characters should be written as `\\` (escaped).
 
 # Files and Folders to Exclude
 

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -17,6 +17,7 @@ const requiredFields = [
 ];
 
 const optionalFields = [
+    'PLAYCANVAS_USE_CWD_AS_TARGET',
     'PLAYCANVAS_INCLUDE_REG',
     'PLAYCANVAS_FORCE_REG',
     'PLAYCANVAS_DRY_RUN',
@@ -82,9 +83,15 @@ class ConfigVars {
     }
 
     async checkPrepTarg() {
-        let s = this.result.PLAYCANVAS_TARGET_DIR || '';
+        let s = this.result.PLAYCANVAS_TARGET_DIR ||
+            (this.result.PLAYCANVAS_USE_CWD_AS_TARGET && process.cwd()) ||
+            '';
 
         s = PathUtils.rmLastSlash(s);
+
+        if (s === require.main.path) {
+            CUtils.throwFtError('Error: do not use the playcanvas-sync directory as target');
+        }
 
         const stat = await PathUtils.fsWrap('stat', s);
 


### PR DESCRIPTION
Allow the current working dir as target dir, if PLAYCANVAS_USE_CWD_AS_TARGET is set in ~/.pcconfig