### PR TITLE
Increment asset list request limit

### DIFF
--- a/src/load-assets.js
+++ b/src/load-assets.js
@@ -1,6 +1,6 @@
 const CUtils = require('./utils/common-utils');
 
-const ASSET_QRY_LIMIT = 1000;
+const ASSET_QRY_LIMIT = 100000;
 
 class LoadAssets {
   constructor(conf) {


### PR DESCRIPTION
Use a high limit in an asset list api request. The editor does not use a limit at all when it gets its list of assets. pcsync won't work without a limit argument in its request, probably because there's an exception for the editor in the asset server. So we simply pass a high limit here. The problem with pagination seems to be caused by DocumentDb's and Mongos inability to always paginate query results correctly for db tables that are being constantly updated (unless we have an issue in our asset server code). Paginated responses have multiples copies of the same assets, while omitting some others. We are not seeing issues with large projects in the editor, because as mentioned, the editor requests the whole list at once without pagination.