### PR TITLE
Implement support for PLAYCANVAS_TARGET_SUBDIR config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,19 @@ and environment variables.
 
 `PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable. You
 can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use
-your current working directory as your target.
+your current working directory (CWD) as your target.
+
+For some workflows, it may be necessary to
+keep the `pcconfig.json` file
+in CWD, but treat one of CWD's subdirectories as
+the root of the local file hierarchy. In such cases both 
+`PLAYCANVAS_USE_CWD_AS_TARGET`
+and `PLAYCANVAS_CWD_SUBDIR` need to be provided,
+the latter can be in `pcconfig.json`, e.g.
+
+```
+"PLAYCANVAS_CWD_SUBDIR": "src"
+```
 
 Backslash characters should be written as `\\` (escaped).
 

--- a/README.md
+++ b/README.md
@@ -244,18 +244,16 @@ and environment variables.
 
 `PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable. You
 can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use
-your current working directory (CWD) as your target.
+your current working directory as your target.
 
 For some workflows, it may be necessary to
-keep the `pcconfig.json` file
-in CWD, but treat one of CWD's subdirectories as
-the root of the local file hierarchy. In such cases both 
-`PLAYCANVAS_USE_CWD_AS_TARGET`
-and `PLAYCANVAS_CWD_SUBDIR` need to be provided,
-the latter can be in `pcconfig.json`, e.g.
+keep the `pcconfig.json` file at the top level
+in the target directory, but treat one of its subdirectories as
+the root of the local file hierarchy. In such cases 
+`PLAYCANVAS_TARGET_SUBDIR` needs to be provided, e.g.
 
 ```
-"PLAYCANVAS_CWD_SUBDIR": "src"
+"PLAYCANVAS_TARGET_SUBDIR": "src"
 ```
 
 Backslash characters should be written as `\\` (escaped).

--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -271,6 +271,19 @@ const CUtils = {
 
     waitMs: function (ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
+    },
+
+    checkTargetExists: async function(fullPath) {
+        const stat = await PathUtils.fsWrap('stat', fullPath);
+
+        const good = stat && stat.isDirectory;
+
+        if (!good) {
+            const s = `Error: could not find target directory: ${fullPath}. ` +
+                'Check capitalization.';
+
+            CUtils.throwFtError(s);
+        }
     }
 };
 

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -18,7 +18,7 @@ const requiredFields = [
 
 const optionalFields = [
     'PLAYCANVAS_USE_CWD_AS_TARGET',
-    'PLAYCANVAS_CWD_SUBDIR',
+    'PLAYCANVAS_TARGET_SUBDIR',
     'PLAYCANVAS_INCLUDE_REG',
     'PLAYCANVAS_FORCE_REG',
     'PLAYCANVAS_DRY_RUN',
@@ -120,8 +120,7 @@ class ConfigVars {
     }
 
     async addSubdirToTarget() {
-        let s = this.result.PLAYCANVAS_USE_CWD_AS_TARGET &&
-            this.result.PLAYCANVAS_CWD_SUBDIR;
+        let s = this.result.PLAYCANVAS_TARGET_SUBDIR;
 
         if (s) {
             s = PathUtils.rmLastSlash(s);

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -120,8 +120,11 @@ class ConfigVars {
     }
 
     async addSubdirToTarget() {
-        if (this.result.PLAYCANVAS_CWD_SUBDIR) {
-            const s = PathUtils.rmLastSlash(this.result.PLAYCANVAS_CWD_SUBDIR);
+        let s = this.result.PLAYCANVAS_USE_CWD_AS_TARGET &&
+            this.result.PLAYCANVAS_CWD_SUBDIR;
+
+        if (s) {
+            s = PathUtils.rmLastSlash(s);
 
             this.result.PLAYCANVAS_TARGET_DIR = path.join(
                 this.result.PLAYCANVAS_TARGET_DIR,

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -68,7 +68,7 @@ class ConfigVars {
 
         this.fromConfigFile(this.result.PLAYCANVAS_TARGET_DIR, TARGET_CONFIG_FILE);
 
-        this.addSubdirToTarget();
+        await this.addSubdirToTarget();
 
         this.fromDefaults();
 
@@ -96,14 +96,9 @@ class ConfigVars {
             CUtils.throwFtError('Error: do not use the playcanvas-sync directory as target');
         }
 
-        const stat = await PathUtils.fsWrap('stat', s);
+        await CUtils.checkTargetExists(s);
 
-        if (stat && stat.isDirectory) {
-            this.result.PLAYCANVAS_TARGET_DIR = s;
-
-        } else {
-            CUtils.throwFtError(`Error: could not find target directory: ${s}. Check capitalization.`);
-        }
+        this.result.PLAYCANVAS_TARGET_DIR = s;
     }
 
     fromEnvOrMap(h) {
@@ -124,7 +119,7 @@ class ConfigVars {
         }
     }
 
-    addSubdirToTarget() {
+    async addSubdirToTarget() {
         if (this.result.PLAYCANVAS_CWD_SUBDIR) {
             const s = PathUtils.rmLastSlash(this.result.PLAYCANVAS_CWD_SUBDIR);
 
@@ -132,6 +127,8 @@ class ConfigVars {
                 this.result.PLAYCANVAS_TARGET_DIR,
                 s
             );
+
+            await CUtils.checkTargetExists(this.result.PLAYCANVAS_TARGET_DIR);
         }
     }
 

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -18,6 +18,7 @@ const requiredFields = [
 
 const optionalFields = [
     'PLAYCANVAS_USE_CWD_AS_TARGET',
+    'PLAYCANVAS_CWD_SUBDIR',
     'PLAYCANVAS_INCLUDE_REG',
     'PLAYCANVAS_FORCE_REG',
     'PLAYCANVAS_DRY_RUN',
@@ -66,6 +67,8 @@ class ConfigVars {
         await this.checkPrepTarg();
 
         this.fromConfigFile(this.result.PLAYCANVAS_TARGET_DIR, TARGET_CONFIG_FILE);
+
+        this.addSubdirToTarget();
 
         this.fromDefaults();
 
@@ -118,6 +121,17 @@ class ConfigVars {
     checkRequired(field) {
         if (!this.result[field]) {
             CUtils.throwUsError(`Missing config variable: ${field}`);
+        }
+    }
+
+    addSubdirToTarget() {
+        if (this.result.PLAYCANVAS_CWD_SUBDIR) {
+            const s = PathUtils.rmLastSlash(this.result.PLAYCANVAS_CWD_SUBDIR);
+
+            this.result.PLAYCANVAS_TARGET_DIR = path.join(
+                this.result.PLAYCANVAS_TARGET_DIR,
+                s
+            );
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/playcanvas-sync/issues/34

For some workflows, it may be necessary to
keep the pcconfig.json file at the top level
in the target directory, but treat one of its subdirectories as
the root of the local file hierarchy. In such cases 
PLAYCANVAS_TARGET_SUBDIR needs to be provided