### PR TITLE
Fix the force option

### DIFF
--- a/pcwatch.js
+++ b/pcwatch.js
@@ -16,7 +16,7 @@ program.option('-f, --force', 'skip local/remote equality check');
 program.parse(process.argv);
 
 async function run() {
-    if (!program.force) {
+    if (!program.opts().force) {
         await CUtils.wrapUserErrors(() => SyncUtils.errorIfDifferent(true));
 
         await CUtils.wrapUserErrors(SyncUtils.errorIfMultWatch);


### PR DESCRIPTION
According to [the doc of commander](https://github.com/tj/commander.js#options) we can get an option value using .opts()

I'm not sure about it. But I had a problem  connected with force pulling.