### PR TITLE
Add getEditorBranches to ApiClient

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -111,6 +111,32 @@ class ApiClient {
 
     return JSON.parse(resp);
   }
+  
+  async getEditorBranches(projectId) {
+    const url = `/projects/${projectId}/branches`;
+
+    const branches = [];
+    let hasMore = true;
+    let branchId = undefined;
+
+    while (hasMore) {
+      const resp = await this.methodGet(
+        url + (branchId ? "skip=" + branchId : ""),
+        BRANCHES_PREF,
+        true
+      );
+
+      const respData = JSON.parse(resp);
+
+      hasMore = respData.pagination.hasMore;
+
+      branches.push(...respData.result);
+
+      branchId = respData.result[respData.result.length - 1].id;
+    }
+
+    return branches;
+  }
 }
 
 module.exports = ApiClient;


### PR DESCRIPTION
Add ability to get a list of all branches.

`getEditorBranches` and `getCurEditorBranch` allow to get information about current editor branch. For example, a user can check the current branch of Editor and the current git branch by name to prevent unexpected overwriting content in Editor just because a user forget to switch branches in Playcanvas Editor and Git.