### PR TITLE
Fix getAssetId for remotePath === "."

### DIFF
--- a/src/asset-store.js
+++ b/src/asset-store.js
@@ -34,9 +34,9 @@ class AssetStore {
     }
 
     getAssetId(remotePath) {
-        const a = this.getAssetAtPath(remotePath);
-
-        return a.id
+        return remotePath !== "." ?
+            this.getAssetAtPath(remotePath).id :
+            null
     }
 
     getAssetAtPath(remotePath) {


### PR DESCRIPTION
For the **"."** path, ID is suggested to be equal to null (you can see it in the parent field of assets in the root directory). But right now **getAssetId**  throws an exception [here](https://github.com/playcanvas/playcanvas-sync/blob/main/src/watch-actions/action-renamed.js#L23) when you try to rename an asset into the root directory but parentId for "." has to be **null**