### PR TITLE
Add pow2 setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Sample config file:
   "PLAYCANVAS_TARGET_DIR": "/Users/zpaul/proj1",
   "PLAYCANVAS_API_KEY": "xyz",
   "PLAYCANVAS_BAD_FILE_REG": "^\\.|~$",
-  "PLAYCANVAS_BAD_FOLDER_REG": "\\."
+  "PLAYCANVAS_BAD_FOLDER_REG": "\\.",
+  "PLAYCANVAS_CONVERT_TO_POW2": 0
 }
 ```
 

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -57,7 +57,7 @@ class ApiClient {
         });
     }
 
-    methodPost(url, pref, addToken, poyload) {
+    methodPost(url, pref, addToken, payload) {
         url = this.fullUrl(url, pref);
 
         if (addToken) {
@@ -68,7 +68,7 @@ class ApiClient {
             method: 'POST',
             url: url,
             headers: this.headers,
-            body: poyload,
+            body: payload,
             json: true
         });
     }

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -22,7 +22,8 @@ const optionalFields = [
     'PLAYCANVAS_INCLUDE_REG',
     'PLAYCANVAS_FORCE_REG',
     'PLAYCANVAS_DRY_RUN',
-    'PLAYCANVAS_VERBOSE'
+    'PLAYCANVAS_VERBOSE',
+    'PLAYCANVAS_CONVERT_TO_POW2'
 ];
 
 const allConfigFields = requiredFields.concat(optionalFields);
@@ -103,13 +104,13 @@ class ConfigVars {
 
     fromEnvOrMap(h) {
         allConfigFields.forEach((field) => {
-            this.result[field] = process.env[field] || h[field] || this.result[field];
+            this.result[field] = process.env[field] ?? h[field] ?? this.result[field];
         });
     }
 
     fromDefaults() {
         allConfigFields.forEach((field) => {
-            this.result[field] = this.result[field] || fieldsWithDefaults[field];
+            this.result[field] = this.result[field] ?? fieldsWithDefaults[field];
         });
     }
 

--- a/src/watch-actions/action-created.js
+++ b/src/watch-actions/action-created.js
@@ -33,6 +33,10 @@ class ActionCreated {
     createFile() {
         const h = { preload: 'true' };
 
+        if (this.conf.PLAYCANVAS_CONVERT_TO_POW2 !== undefined) {
+            h.pow2 = this.conf.PLAYCANVAS_CONVERT_TO_POW2 ? 'true' : 'false';
+        }
+
         return this.callApi(h, this.data.fullPath);
     }
 

--- a/src/watch-actions/watch-utils.js
+++ b/src/watch-actions/watch-utils.js
@@ -15,6 +15,10 @@ const WatchUtils = {
             branchId: conf.PLAYCANVAS_BRANCH_ID,
             file: fs.createReadStream(data.fullPath)
         };
+ 
+        if (conf.PLAYCANVAS_CONVERT_TO_POW2 !== undefined) {
+            h.pow2 = conf.PLAYCANVAS_CONVERT_TO_POW2 ? 'true' : 'false';
+        }
 
         await conf.client.putForm(url, h);
 


### PR DESCRIPTION
closes #56

Not working yet unfortunately. For some reason the `pow2` field results in a 400 bad request with the following message:

```json
{
	"error": "pow2: not supported field"
}
```

even though I can see that the editor uses the same API endpoint 🤔