### PR TITLE
ci setup for npm publishing #46

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      # TODO: Add back in after linting issues have been resolved.
+      # - run: npm lint
+      - run: npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/bin/pcsync.js
+++ b/bin/pcsync.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const OverwriteAllLocalWithRemote = require('./src/sync-commands/overwrite-all-local-with-remote');
-const OverwriteAllRemoteWithLocal = require('./src/sync-commands/overwrite-all-remote-with-local');
-const CUtils = require('./src/utils/common-utils');
-const SyncUtils = require('./src/sync-commands/sync-utils');
-const SCUtils = require('./src/sync-commands/sync-command-utils');
+const OverwriteAllLocalWithRemote = require('../src/sync-commands/overwrite-all-local-with-remote');
+const OverwriteAllRemoteWithLocal = require('../src/sync-commands/overwrite-all-remote-with-local');
+const CUtils = require('../src/utils/common-utils');
+const SyncUtils = require('../src/sync-commands/sync-utils');
+const SCUtils = require('../src/sync-commands/sync-command-utils');
 
 const program = require('commander');
 

--- a/bin/pcwatch.js
+++ b/bin/pcwatch.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-const GetConfig = require('./src/utils/get-config');
+const GetConfig = require('../src/utils/get-config');
 const program = require('commander');
 
-const CUtils = require('./src/utils/common-utils');
-const WatchUtils = require('./src/watch-actions/watch-utils');
-const ActionCreated = require('./src/watch-actions/action-created');
-const SyncUtils = require('./src/sync-commands/sync-utils');
-const LocalWatcher = require('./src/utils/local-watcher');
-const CacheUtils = require('./src/utils/cache-utils');
-const LocalTraversal = require('./src/utils/local-traversal');
+const CUtils = require('../src/utils/common-utils');
+const WatchUtils = require('../src/watch-actions/watch-utils');
+const ActionCreated = require('../src/watch-actions/action-created');
+const SyncUtils = require('../src/sync-commands/sync-utils');
+const LocalWatcher = require('../src/utils/local-watcher');
+const CacheUtils = require('../src/utils/cache-utils');
+const LocalTraversal = require('../src/utils/local-traversal');
 
 program.option('-f, --force', 'skip local/remote equality check');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "request-promise-native": "^1.0.9"
       },
       "bin": {
-        "pcsync": "pcsync.js",
-        "pcwatch": "pcwatch.js"
+        "pcsync": "bin/pcsync.js",
+        "pcwatch": "bin/pcwatch.js"
       },
       "devDependencies": {
         "@playcanvas/eslint-config": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^8.24.0"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/eslint --ext .js,.mjs src bin"
+    "lint": "eslint --ext .js,.mjs src bin"
   },
   "bin": {
     "pcsync": "./bin/pcsync.js",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "sync",
     "local"
   ],
+  "files": [
+    "bin",
+    "docs",
+    "src"
+  ],
   "license": "MIT",
   "main": "index.js",
   "bugs": {
@@ -36,10 +41,10 @@
     "eslint": "^8.24.0"
   },
   "scripts": {
-    "lint": "eslint --ext .js,.mjs src pcsync.js pcwatch.js"
+    "lint": "./node_modules/bin/eslint --ext .js,.mjs src bin"
   },
   "bin": {
-    "pcsync": "./pcsync.js",
-    "pcwatch": "./pcwatch.js"
+    "pcsync": "./bin/pcsync.js",
+    "pcwatch": "./bin/pcwatch.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^8.24.0"
   },
   "scripts": {
-    "lint": "./node_modules/bin/eslint --ext .js,.mjs src bin"
+    "lint": "./node_modules/.bin/eslint --ext .js,.mjs src bin"
   },
   "bin": {
     "pcsync": "./bin/pcsync.js",


### PR DESCRIPTION
Closes #46 #30

# Changelog


- Added workflow to build and publish npm package on release.
- Moved `pcsync` and `pcwatch` to standard `bin` folder.
- `bin` folder is now linted.
- Set full `eslint` path in `package.json` `lint` script.

## Remarks
The playcanvas-sync project seems to have linting setup, but there are a lot of errors.Resolving these issues and running the linter before publishing is out of scope for this PR/issue. 
The linting stage can be commented back in once the issues are resolved.  I propose the linting stage also runs on any pull requests in the future.

@willeastcott This PR will require you to set up a secret on this repo or your organisation called `NPM_TOKEN` https://docs.npmjs.com/about-access-tokens#about-granular-access-tokens

Many thanks :)


