### PR TITLE
Fix mjs update

### DIFF
--- a/src/utils/type-utils.js
+++ b/src/utils/type-utils.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const TEXTUAL_ASSET_TYPES = [
     'text',
     'script',
@@ -8,7 +10,7 @@ const TEXTUAL_ASSET_TYPES = [
 ];
 
 const TYPE_TO_EXT = {
-    'script': ['.js', '.mjs'],  // Add mjs extension
+    'script': ['.js', '.mjs'],  // Inclure .mjs dans les types de fichiers pour script
     'scene': ['.fbx', '.dae', '.obj', '.3ds'],
     'text': ['.txt', '.xml', '.atlas'],
     'html': ['.html'],
@@ -27,7 +29,7 @@ TEXTUAL_ASSET_TYPES.forEach((t) => {
     const a = TYPE_TO_EXT[t];
 
     a.forEach((ext) => {
-        TEXTUAL_EXTENSIONS[ext] = 1;
+        TEXTUAL_EXTENSIONS[ext.toLowerCase()] = 1;  // Assure-toi que toutes les extensions sont en minuscules
     });
 });
 
@@ -61,7 +63,7 @@ const TypeUtils = {
     },
 
     isTextualFile: function (s) {
-        const ext = path.extname(s);
+        const ext = path.extname(s).toLowerCase();  // Convertir l'extension en minuscule
 
         return TEXTUAL_EXTENSIONS[ext];
     },

--- a/src/utils/type-utils.js
+++ b/src/utils/type-utils.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const TEXTUAL_ASSET_TYPES = [
     'text',
     'script',
@@ -10,7 +8,7 @@ const TEXTUAL_ASSET_TYPES = [
 ];
 
 const TYPE_TO_EXT = {
-    'script': ['.js', '.mjs'],
+    'script': ['.js', '.mjs'],  // Add mjs extension
     'scene': ['.fbx', '.dae', '.obj', '.3ds'],
     'text': ['.txt', '.xml', '.atlas'],
     'html': ['.html'],

--- a/src/utils/type-utils.js
+++ b/src/utils/type-utils.js
@@ -63,7 +63,7 @@ const TypeUtils = {
     },
 
     isTextualFile: function (s) {
-        const ext = path.extname(s).toLowerCase();  // Convertir l'extension en minuscule
+        const ext = path.extname(s).toLowerCase();  // Uppercase to lowercase to avoid case sensitivity
 
         return TEXTUAL_EXTENSIONS[ext];
     },


### PR DESCRIPTION
While working on a git synchronization workflow, I noticed that the mjs were not taken for synchronization despite the fact that they are in the types authorized in `const TYPE_TO_EXT `

After a few tests, it was due to a lowercase/uppercase problem, so I added a line to standardize lowercase names.

```
isTextualFile: function (s) {
        const ext = path.extname(s).toLowerCase();  // Uppercase to lowercase to avoid case sensitivity
        return TEXTUAL_EXTENSIONS[ext];
    },
```