### PR TITLE
Fix mjs update

### DIFF
--- a/src/utils/type-utils.js
+++ b/src/utils/type-utils.js
@@ -29,7 +29,7 @@ TEXTUAL_ASSET_TYPES.forEach((t) => {
     const a = TYPE_TO_EXT[t];
 
     a.forEach((ext) => {
-        TEXTUAL_EXTENSIONS[ext] = 1;
+        TEXTUAL_EXTENSIONS[ext.toLowerCase()] = 1;
     });
 });
 
@@ -63,7 +63,7 @@ const TypeUtils = {
     },
 
     isTextualFile: function (s) {
-        const ext = path.extname(s);
+        const ext = path.extname(s).toLowerCase();  // Uppercase to lowercase to avoid case sensitivity
 
         return TEXTUAL_EXTENSIONS[ext];
     },

--- a/src/utils/type-utils.js
+++ b/src/utils/type-utils.js
@@ -29,7 +29,7 @@ TEXTUAL_ASSET_TYPES.forEach((t) => {
     const a = TYPE_TO_EXT[t];
 
     a.forEach((ext) => {
-        TEXTUAL_EXTENSIONS[ext.toLowerCase()] = 1;
+        TEXTUAL_EXTENSIONS[ext] = 1;
     });
 });
 


### PR DESCRIPTION
While working on a git workflow, I noticed that the mjs were not taken for synchronization despite the fact that they are in the types authorized in `const TYPE_TO_EXT `

After a few tests, it was due to a lowercase/uppercase problem, so I added a line to standardize lowercase names.

```
isTextualFile: function (s) {
        const ext = path.extname(s).toLowerCase();  // Uppercase to lowercase to avoid case sensitivity
        return TEXTUAL_EXTENSIONS[ext];
    },
```