### PR TITLE
feat: modernize CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In addition, if your project has a file called [`pcignore.txt`](#the-pcignoretxt
 
 `pcsync` is used to push or pull one or all files to or from PlayCanvas (overwriting existing files with the same name/path), to compare one or all local files to their remote (PlayCanvas) versions, and to watch for local changes and sync them in real time.
 
-Only the `pcsync pull` command (when downloading) can change local files. Other `pcsync` commands change only remote files. Thus your local directory holds the authoritative version of your textual files.
+Only the `pcsync pull` command (when downloading) and the `pcsync init` command (which creates or overwrites `pcconfig.json`) can change local files. All other `pcsync` commands change only remote files. Thus, apart from `pcconfig.json`, your local directory holds the authoritative version of your textual files.
 
 The only scenario we do not support is when developer A uses `pcsync watch`, while developer B is editing files of the *same PlayCanvas branch* in the browser code editor. B's work will be overwritten by A, if they edit the same file. Either B should start using local files, or A should stop `pcsync watch` and switch to the browser code editor.
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,51 @@
 # Overview
 
-The `pcsync` and `pcwatch` utilities allow editing copies of JavaScript and other textual files of a PlayCanvas project locally on your own computer, in a text editor of your choice.
+The `pcsync` utility allows editing copies of JavaScript and other textual files of a PlayCanvas project locally on your own computer, in a text editor of your choice.
 
 `pcsync` also allows pushing and pulling of [binary files](#using-pcsync-for-binary-files), such as images and models.
 
-In addition, if your project has a file called [`pcignore.txt`](#the-pcignoretxt-file), PlayCanvas merge will not affect the files listed in it, and the operation of `pcsync` and `pcwatch` will be restricted only to those files.
+In addition, if your project has a file called [`pcignore.txt`](#the-pcignoretxt-file), PlayCanvas merge will not affect the files listed in it, and the operation of `pcsync` will be restricted only to those files.
 
-`pcsync` is used to push or pull one or all files to or from PlayCanvas (overwriting existing files with the same name/path) and to compare one or all local files to their remote (PlayCanvas) versions.
+`pcsync` is used to push or pull one or all files to or from PlayCanvas (overwriting existing files with the same name/path), to compare one or all local files to their remote (PlayCanvas) versions, and to watch for local changes and sync them in real time.
 
-`pcwatch` detects changes to local files and folders (edits, removals and creation) as they happen and applies them to PlayCanvas in real time.
+Only the `pcsync pull` command (when downloading) can change local files. Other `pcsync` commands change only remote files. Thus your local directory holds the authoritative version of your textual files.
 
-If you do not need your local changes pushed to PlayCanvas "as you type", you do not have to use `pcwatch`. Running `pcsync pushAll` periodically can be sufficient.
-
-Only the `pcsync pull` and `pcsync pullAll` commands can change local files. Other `pcsync` commands and `pcwatch` change only remote files. Thus your local directory holds the authoritative version of your textual files.
-
-The only scenario we do not support is when developer A uses `pcwatch`, while developer B is editing files of the *same PlayCanvas branch* in the browser code editor. B's work will be overwritten by A, if they edit the same file. Either B should start using local files, or A should stop `pcwatch` and switch to the browser code editor.
+The only scenario we do not support is when developer A uses `pcsync watch`, while developer B is editing files of the *same PlayCanvas branch* in the browser code editor. B's work will be overwritten by A, if they edit the same file. Either B should start using local files, or A should stop `pcsync watch` and switch to the browser code editor.
 
 # The `pcsync` Utility
 
 `pcsync` has the following commands:
 
 ```
-  diffAll                     compare all local and remote files and folders
-  diff <filePath>             show line-by-line diff of the remote and local files at filePath
-  pullAll                     download all remote files, overwriting their local counterparts
-  pushAll                     upload all local files, overwriting their remote counterparts
-  pull <filePath>             download remote file, creating local folders if needed
-  push <filePath>             upload local file, creating remote folders if needed
-  rename <oldPath> <newPath>  rename remote file or folder, change its parent folder if needed
-  rm <filePath>               remove remote file or folder
-  parseIgnore                 list assets matched by pcignore.txt
+  diff [file]                 compare local and remote files (all files if no file specified)
+  pull [file]                 download remote files to local (all files if no file specified)
+  push [file]                 upload local files to remote (all files if no file specified)
+  rename <oldPath> <newPath>  rename or move a remote file or folder
+  rm <path>                   remove a remote file or folder
+  watch                       watch local directory and sync changes to remote in real-time
+  ignore                      list assets matched by pcignore.txt
+  init                        create a pcconfig.json in the current directory
 ```
+
+## Global Options
+
+The following options are available on all commands:
+
+```
+  -k, --api-key <key>     PlayCanvas API key (overrides config)
+  -p, --project-id <id>   PlayCanvas project ID (overrides config)
+  -b, --branch-id <id>    PlayCanvas branch ID (overrides config)
+  -t, --target-dir <dir>  local target directory (overrides config)
+      --base-url <url>    PlayCanvas API base URL (overrides config)
+  -n, --dry-run           show what would happen without making changes
+      --verbose           print detailed output including config values
+  -V, --version           output the version number
+  -h, --help              display help
+```
+
+These override the corresponding config file and environment variable values for the duration of the command, which is useful for CI/CD scripting or one-off operations.
+
+## File Paths
 
 A local directory [designated](#config-variables) as `PLAYCANVAS_TARGET_DIR` corresponds to the root of the PlayCanvas file and folder asset hierarchy.
 
@@ -42,17 +57,72 @@ pcsync rename dir1/file1.js file1.js
 
 will move `file1.js` to the root asset directory.
 
-`pushAll` and `pullAll` accept an optional `-y` or `--yes` flag to automatically answer "yes" to confirmation prompts.
+## Command Details
 
-# The `pcwatch` Utility
+### `pcsync diff [file]`
 
-`pcwatch` does not need any options.
+Without a file argument, compares all local and remote files and folders. With a file argument, shows a line-by-line diff of that specific file.
 
-Moving or renaming a file or a folder will appear to `pcwatch` as a `remove + create`. In such cases it may be better to stop `pcwatch`, perform the operation locally, apply it to PlayCanvas with `pcsync rename`, and start `pcwatch` again.
+Options for comparing all files:
+
+```
+  -r, --regexp <pattern>   filter files matching the provided regular expression
+  -e, --ext <extensions>   filter files by extension (comma-separated, e.g. jpg,png)
+```
+
+### `pcsync pull [file]`
+
+Without a file argument, downloads all remote files, overwriting their local counterparts. With a file argument, downloads that single remote file, creating local folders if needed.
+
+Options for downloading all files:
+
+```
+  -r, --regexp <pattern>   filter files matching the provided regular expression
+  -e, --ext <extensions>   filter files by extension (comma-separated, e.g. jpg,png)
+  -y, --yes                skip confirmation prompt
+```
+
+### `pcsync push [file]`
+
+Without a file argument, uploads all local files, overwriting their remote counterparts. With a file argument, uploads that single local file, creating remote folders if needed.
+
+Options for uploading all files:
+
+```
+  -r, --regexp <pattern>   filter files matching the provided regular expression
+  -e, --ext <extensions>   filter files by extension (comma-separated, e.g. jpg,png)
+  -y, --yes                skip confirmation prompt
+```
+
+### `pcsync rename <oldPath> <newPath>`
+
+Rename or move a remote file or folder. Changes the parent folder if needed.
+
+### `pcsync rm <path>`
+
+Remove a remote file or folder.
+
+### `pcsync watch`
+
+Watch the local directory for changes and sync them to remote in real time.
+
+```
+  -f, --force   skip local/remote equality and multi-instance checks
+```
+
+Moving or renaming a file or a folder will appear to `pcsync watch` as a `remove + create`. In such cases it may be better to stop `pcsync watch`, perform the operation locally, apply it to PlayCanvas with `pcsync rename`, and start `pcsync watch` again.
+
+### `pcsync ignore`
+
+List all assets matched by your current `pcignore.txt`. Useful for checking your `pcignore.txt` syntax.
+
+### `pcsync init`
+
+Interactive setup wizard that creates a `pcconfig.json` in the current directory. Prompts for API key, project ID, branch ID and target directory.
 
 # Adding New Files as Script Components
 
-Assume file F was created locally and pushed to PlayCanvas with `pcsync` or `pcwatch`, and now you are adding F as a script component to an entity in PlayCanvas Editor.
+Assume file F was created locally and pushed to PlayCanvas with `pcsync`, and now you are adding F as a script component to an entity in PlayCanvas Editor.
 
 Note that it will take a second or two for F to appear in the dropdown list, because F is parsed by the editor for the first time when that list is populated.
 
@@ -60,9 +130,9 @@ Note that it will take a second or two for F to appear in the dropdown list, bec
 
 If your project has a file called `pcignore.txt` in the root folder, any file listed there will be the same before and after a PlayCanvas merge.
 
-The operation of `pcsync` and `pcwatch` is restricted to the files listed in `pcignore.txt`, if `pcignore.txt` exists. This ensures that the set of files managed locally exactly matches the set ignored by PlayCanvas merge, which is appropriate for most workflows.
+The operation of `pcsync` is restricted to the files listed in `pcignore.txt`, if `pcignore.txt` exists. This ensures that the set of files managed locally exactly matches the set ignored by PlayCanvas merge, which is appropriate for most workflows.
 
-To make `pcsync` and `pcwatch` work with more files than listed in `pcignore.txt`, use the `PLAYCANVAS_INCLUDE_REG` config variable, which is a regular expression to test each file's path from the root of the asset hierarchy.
+To make `pcsync` work with more files than listed in `pcignore.txt`, use the `PLAYCANVAS_INCLUDE_REG` config variable, which is a regular expression to test each file's path from the root of the asset hierarchy.
 
 Before a PlayCanvas merge, make sure that the latest checkpoint of the destination branch is taken after `pcignore.txt` was added.
 
@@ -86,7 +156,7 @@ source_branch_wins
 
 Multiple `ignore_regexp` lines can be provided. Any textual asset whose path from the root of the asset hierarchy matches an `ignore_regexp` expression will be ignored.
 
-To check your `pcignore.txt` syntax, you can run `pcsync parseIgnore`. It will list all existing files that match your current `pcignore.txt`.
+To check your `pcignore.txt` syntax, you can run `pcsync ignore`. It will list all existing files that match your current `pcignore.txt`.
 
 Use a space and not * or ? to match a space in a file or folder name in gitignore lines.
 
@@ -94,20 +164,20 @@ Use a space and not * or ? to match a space in a file or folder name in gitignor
 
 Binary files include assets such as textures (JPG and PNG) and models (GLB).
 
-`push`, `pull` (single file) and `rm` work with binary file arguments without any special options.
+`push`, `pull` (with a single file argument) and `rm` work with binary file arguments without any special options.
 
-`pushAll`, `pullAll` and `diffAll` have two options that make them work with matching files only, including binary (without one of these options `pcsync` only works with textual files):
+When running `push`, `pull` or `diff` without a file argument, you can use the `-r` or `-e` options to include binary files (without these options `pcsync` only works with textual files):
 
 ```
-  -e, --ext <extensions>  handle files with provided extensions
-  -r, --regexp <regexp>   handle files matching the provided regular expression
+  -e, --ext <extensions>  filter files by extension (comma-separated)
+  -r, --regexp <pattern>  filter files matching the provided regular expression
 ```
 
 For instance:
 
 ```
-pcsync diffAll -e jpeg,png
-pcsync pushAll -r "\\.(png|jpeg)"
+pcsync diff -e jpeg,png
+pcsync push -r "\\.(png|jpeg)"
 ```
 
 The regular expression tests each file's path from the root.
@@ -122,7 +192,7 @@ Install globally from npm:
 npm install -g playcanvas-sync
 ```
 
-This makes the `pcsync` and `pcwatch` commands available system-wide.
+This makes the `pcsync` command available system-wide.
 
 To uninstall:
 
@@ -130,9 +200,26 @@ To uninstall:
 npm uninstall -g playcanvas-sync
 ```
 
+## Quick Start
+
+After installation, the fastest way to get started is:
+
+```
+mkdir my-project && cd my-project
+pcsync init
+pcsync pull
+```
+
 # Config Variables
 
-Config variables can be set in a file called `.pcconfig` in your home directory, in `pcconfig.json` in your target directory (and your remote PlayCanvas branch), or provided as environment variables (which would have the highest precedence).
+Config variables can be set in a file called `.pcconfig` in your home directory, in `pcconfig.json` in your target directory (and your remote PlayCanvas branch), provided as environment variables, or passed as CLI options (which have the highest precedence).
+
+The precedence order (highest to lowest) is:
+
+1. CLI options (`--api-key`, `--project-id`, etc.)
+2. Environment variables (`PLAYCANVAS_API_KEY`, etc.)
+3. Config files (`.pcconfig`, `pcconfig.json`)
+4. Built-in defaults
 
 The home directory location is:
 
@@ -180,7 +267,9 @@ A sample `.pcconfig` should look like this:
 
 All listed key-value pairs are necessary. You can split them between `.pcconfig` (in your home directory), `pcconfig.json` (in your project target directory), and environment variables.
 
-`PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig` or an environment variable. You can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use your current working directory as your target.
+Alternatively, use `pcsync init` to generate a `pcconfig.json` interactively.
+
+`PLAYCANVAS_TARGET_DIR` can only be set in `.pcconfig`, an environment variable, or via `--target-dir`. You can also set `PLAYCANVAS_USE_CWD_AS_TARGET` to `1` in `.pcconfig` to use your current working directory as your target.
 
 For some workflows, it may be necessary to keep the `pcconfig.json` file at the top level in the target directory, but treat one of its subdirectories as the root of the local file hierarchy. In such cases `PLAYCANVAS_TARGET_SUBDIR` needs to be provided, e.g.
 
@@ -194,51 +283,59 @@ Backslash characters should be written as `\\` (escaped).
 
 Many text editors and operating systems create local auxiliary files and directories that do not need to be automatically pushed to PlayCanvas.
 
-`PLAYCANVAS_BAD_FILE_REG` and `PLAYCANVAS_BAD_FOLDER_REG` contain RegExp strings (note the escapes) that tell `pcwatch` which files and directories to ignore. In our sample `.pcconfig`, a bad file has a name that starts with a dot or ends with `~`. A bad folder is one that has a dot anywhere in its path relative to `PLAYCANVAS_TARGET_DIR`. The expressions provided are sufficient in most cases, and you can simply copy them into your `.pcconfig`.
+`PLAYCANVAS_BAD_FILE_REG` and `PLAYCANVAS_BAD_FOLDER_REG` contain RegExp strings (note the escapes) that tell `pcsync watch` which files and directories to ignore. In our sample `.pcconfig`, a bad file has a name that starts with a dot or ends with `~`. A bad folder is one that has a dot anywhere in its path relative to `PLAYCANVAS_TARGET_DIR`. The expressions provided are sufficient in most cases, and you can simply copy them into your `.pcconfig`.
 
-To determine which auxiliary files and folders your OS and text editor create, run `pcwatch` with config/environment variables `PLAYCANVAS_DRY_RUN` and `PLAYCANVAS_VERBOSE` set to `1`, and create/edit some files.
+To determine which auxiliary files and folders your OS and text editor create, run `pcsync watch` with the `--verbose` and `--dry-run` flags, and create/edit some files.
 
-`pcwatch` output will show all file system events as they happen, and which of them will be filtered out by your current `PLAYCANVAS_BAD_FILE_REG` and `PLAYCANVAS_BAD_FOLDER_REG`.
+```
+pcsync watch --verbose --dry-run
+```
+
+The output will show all file system events as they happen, and which of them will be filtered out by your current `PLAYCANVAS_BAD_FILE_REG` and `PLAYCANVAS_BAD_FOLDER_REG`.
 
 If in your case no bad files and folders exist, use a string like `"matchNothing"` as the value of `PLAYCANVAS_BAD_FILE_REG` and/or `PLAYCANVAS_BAD_FOLDER_REG`.
 
 # Troubleshooting
 
-Problems are often caused by setting config variables incorrectly. Execute your command with the config/environment variable `PLAYCANVAS_VERBOSE` set to `1` to print the current values of all config variables and other useful data.
+Problems are often caused by setting config variables incorrectly. Execute your command with `--verbose` to print the current values of all config variables and other useful data:
+
+```
+pcsync diff --verbose
+```
 
 # Sample Workflows
 
 ## Case 1: Single user per PlayCanvas branch, without `git`
 
-* Run `pcsync pullAll` to download existing textual files from PlayCanvas
-* Launch `pcwatch`
+* Run `pcsync pull` to download existing textual files from PlayCanvas
+* Launch `pcsync watch`
 * Start editing/creating files locally in your own text editor
 
 To merge changes from another PlayCanvas branch into your branch without `git`:
 
-* Stop `pcwatch`
-* Run `pcsync diffAll`, and, if necessary, `pcsync push/pushAll` to make sure the PlayCanvas version is up-to-date.
+* Stop `pcsync watch`
+* Run `pcsync diff`, and, if necessary, `pcsync push` to make sure the PlayCanvas version is up-to-date.
 * Perform merge in PlayCanvas
-* Use `pcsync pullAll` to download the merge result
+* Use `pcsync pull` to download the merge result
 
 ## Case 2: Single user per PlayCanvas branch, with `git`
 
 * Create your own PlayCanvas branch of your team's project
 * Create a git branch for your work, and make it your local target directory
 * Create a [`pcignore.txt`](#the-pcignoretxt-file) file, listing all files you intend to keep in git, create a PlayCanvas checkpoint that includes your `pcignore.txt`
-* Launch `pcwatch`
+* Launch `pcsync watch`
 * Start editing/creating files locally in your own text editor
 * When necessary, merge in `git` the branch of another group member into your branch
-* Use `pcsync pushAll` to update your remote branch after git merge
+* Use `pcsync push` to update your remote branch after git merge
 * Merge the same branches in PlayCanvas
-* Use `pcsync diffAll` to verify that local and remote files are still in sync
+* Use `pcsync diff` to verify that local and remote files are still in sync
 
 ## Case 3: Multiple users working on the same PlayCanvas branch, with `git`
 
 Most items from Case 1 apply, also:
 
-* Periodically run `pcsync diffAll`. It is usually OK to see extra remote files (coming from other team members). If you notice that a remote file is different from your local file, consider a `git` merge to include your team member's changes into your `git` branch, resolve conflicts in `git`, if any, as usual.
-* Avoid `pcsync pull/pullAll`. To get others' files/changes into your branch, use `git` merge instead to maintain an accurate `git` history of edits to each file (who added what).
+* Periodically run `pcsync diff`. It is usually OK to see extra remote files (coming from other team members). If you notice that a remote file is different from your local file, consider a `git` merge to include your team member's changes into your `git` branch, resolve conflicts in `git`, if any, as usual.
+* Avoid `pcsync pull`. To get others' files/changes into your branch, use `git` merge instead to maintain an accurate `git` history of edits to each file (who added what).
 
 # Using TypeScript
 
@@ -289,6 +386,32 @@ Add `jsconfig.json` and `typings` to `PLAYCANVAS_BAD_FILE_REG` and `PLAYCANVAS_B
 "PLAYCANVAS_BAD_FOLDER_REG": "^\\.|typings"
 ```
 
-Now you are ready to start using `pcsync` and `pcwatch` to sync your PlayCanvas project and edit with VS Code goodness 🚀
+Now you are ready to start using `pcsync` to sync your PlayCanvas project and edit with VS Code goodness 🚀
 
 ![](https://raw.githubusercontent.com/playcanvas/playcanvas-sync/main/docs/images/vs-code-demo.gif)
+
+# Migrating from v2
+
+If you are upgrading from v2, note the following changes:
+
+| v2 Command | v3 Command | Notes |
+|---|---|---|
+| `pcsync diffAll` | `pcsync diff` | No file argument = all files |
+| `pcsync diff <file>` | `pcsync diff <file>` | Unchanged |
+| `pcsync pullAll` | `pcsync pull` | No file argument = all files |
+| `pcsync pull <file>` | `pcsync pull <file>` | Unchanged |
+| `pcsync pushAll` | `pcsync push` | No file argument = all files |
+| `pcsync push <file>` | `pcsync push <file>` | Unchanged |
+| `pcsync parseIgnore` | `pcsync ignore` | Renamed |
+| `pcwatch` | `pcsync watch` | Now a subcommand |
+| `pcwatch -f` | `pcsync watch --force` | Unchanged flag |
+
+The old commands (`diffAll`, `pullAll`, `pushAll`, `parseIgnore`) still work but print a deprecation warning. The standalone `pcwatch` binary also still works with a deprecation warning. Both will be removed in a future major version.
+
+New features in v3:
+
+* **`--version`**: Check which version is installed
+* **`--dry-run`**: See what would happen without making changes (previously config-only)
+* **`--verbose`**: Detailed output including config values (previously config-only)
+* **CLI config overrides**: `--api-key`, `--project-id`, `--branch-id`, `--target-dir`, `--base-url`
+* **`pcsync init`**: Interactive setup wizard for `pcconfig.json`

--- a/bin/pcsync.js
+++ b/bin/pcsync.js
@@ -1,84 +1,257 @@
 #!/usr/bin/env node
 
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
 import { Command } from 'commander';
 
 import OverwriteAllLocalWithRemote from '../src/sync-commands/overwrite-all-local-with-remote.js';
 import OverwriteAllRemoteWithLocal from '../src/sync-commands/overwrite-all-remote-with-local.js';
 import SCUtils from '../src/sync-commands/sync-command-utils.js';
 import SyncUtils from '../src/sync-commands/sync-utils.js';
+import CacheUtils from '../src/utils/cache-utils.js';
 import CUtils from '../src/utils/common-utils.js';
+import GetConfig from '../src/utils/get-config.js';
+import PathUtils from '../src/utils/path-utils.js';
+import ActionCreated from '../src/watch-actions/action-created.js';
+import WatchUtils from '../src/watch-actions/watch-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+
+// ---- global option pre-processing ----
+// Commander only parses parent-level options that appear before the
+// subcommand name.  To allow global options in any position (e.g.
+// "pcsync watch -k KEY"), we extract them from argv first, set them
+// as environment variables, and pass the cleaned argv to Commander.
+
+const VALUE_OPTS = {
+    '-k': 'PLAYCANVAS_API_KEY',
+    '--api-key': 'PLAYCANVAS_API_KEY',
+    '-p': 'PLAYCANVAS_PROJECT_ID',
+    '--project-id': 'PLAYCANVAS_PROJECT_ID',
+    '-b': 'PLAYCANVAS_BRANCH_ID',
+    '--branch-id': 'PLAYCANVAS_BRANCH_ID',
+    '-t': 'PLAYCANVAS_TARGET_DIR',
+    '--target-dir': 'PLAYCANVAS_TARGET_DIR',
+    '--base-url': 'PLAYCANVAS_BASE_URL'
+};
+
+const BOOL_OPTS = {
+    '-n': 'PLAYCANVAS_DRY_RUN',
+    '--dry-run': 'PLAYCANVAS_DRY_RUN',
+    '--verbose': 'PLAYCANVAS_VERBOSE'
+};
+
+function preprocessArgs(argv) {
+    const cleaned = [];
+    let i = 0;
+
+    while (i < argv.length) {
+        const arg = argv[i];
+
+        // Handle --option=value syntax
+        const eqIdx = arg.indexOf('=');
+        if (eqIdx !== -1) {
+            const key = arg.substring(0, eqIdx);
+            if (VALUE_OPTS[key]) {
+                process.env[VALUE_OPTS[key]] = arg.substring(eqIdx + 1);
+                i++;
+                continue;
+            }
+        }
+
+        if (VALUE_OPTS[arg] && i + 1 < argv.length) {
+            process.env[VALUE_OPTS[arg]] = argv[i + 1];
+            i += 2;
+        } else if (BOOL_OPTS[arg]) {
+            process.env[BOOL_OPTS[arg]] = '1';
+            i++;
+        } else {
+            cleaned.push(arg);
+            i++;
+        }
+    }
+
+    return cleaned;
+}
 
 const program = new Command();
 
+program
+.name('pcsync')
+.description('Sync files between PlayCanvas and your local machine')
+.version(pkg.version)
+.option('-k, --api-key <key>', 'PlayCanvas API key (overrides config)')
+.option('-p, --project-id <id>', 'PlayCanvas project ID (overrides config)')
+.option('-b, --branch-id <id>', 'PlayCanvas branch ID (overrides config)')
+.option('-t, --target-dir <dir>', 'local target directory (overrides config)')
+.option('--base-url <url>', 'PlayCanvas API base URL (overrides config)')
+.option('-n, --dry-run', 'show what would happen without making changes')
+.option('--verbose', 'print detailed output including config values');
+
+// ---- diff [file] ----
 
 program
-.command('diffAll')
-.description('compare all local and remote files and folders')
-.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
-.option('-e, --ext <extensions>', 'handle files with provided extensions')
-.action(runCompAll);
+.command('diff [file]')
+.description('compare local and remote files (all files if no file specified)')
+.option('-r, --regexp <pattern>', 'filter files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'filter files by extension (comma-separated, e.g. jpg,png)')
+.action((file, cmdObj) => {
+    if (file) {
+        CUtils.wrapUserErrors(() => {
+            return SCUtils.diffSingleFile(file);
+        });
+    } else {
+        CUtils.handleForceRegOpts(cmdObj);
+
+        CUtils.wrapUserErrors(() => {
+            return SyncUtils.reportDiffAll();
+        });
+    }
+});
+
+// ---- pull [file] ----
 
 program
-.command('diff <filePath>')
-.description('show line-by-line diff of the remote and local files at filePath')
-.action(runDiff);
+.command('pull [file]')
+.description('download remote files to local (all files if no file specified)')
+.option('-r, --regexp <pattern>', 'filter files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'filter files by extension (comma-separated, e.g. jpg,png)')
+.option('-y, --yes', 'skip confirmation prompt')
+.action((file, cmdObj) => {
+    if (file) {
+        CUtils.setForceEnv(file);
+
+        CUtils.wrapUserErrors(() => {
+            return SCUtils.downloadSingleFile(file);
+        });
+    } else {
+        CUtils.handleForceRegOpts(cmdObj);
+
+        const cb = function () {
+            return new OverwriteAllLocalWithRemote().run();
+        };
+
+        return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
+    }
+});
+
+// ---- push [file] ----
 
 program
-.command('pullAll')
-.description('download all remote files, overwriting their local counterparts')
-.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
-.option('-e, --ext <extensions>', 'handle files with provided extensions')
-.option('-y, --yes', 'Automatically answer "yes" to any prompts that might print on the command line.')
-.action(runOverwriteAllLocal);
+.command('push [file]')
+.description('upload local files to remote (all files if no file specified)')
+.option('-r, --regexp <pattern>', 'filter files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'filter files by extension (comma-separated, e.g. jpg,png)')
+.option('-y, --yes', 'skip confirmation prompt')
+.action((file, cmdObj) => {
+    if (file) {
+        CUtils.setForceEnv(file);
 
-program
-.command('pushAll')
-.description('upload all local files, overwriting their remote counterparts')
-.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
-.option('-e, --ext <extensions>', 'handle files with provided extensions')
-.option('-y, --yes', 'Automatically answer "yes" to any prompts that might print on the command line.')
-.action(runOverwriteAllRemote);
+        CUtils.wrapUserErrors(() => {
+            return SCUtils.uploadSingleFile(file);
+        });
+    } else {
+        CUtils.handleForceRegOpts(cmdObj);
 
-program
-.command('pull <filePath>')
-.description('download remote file, creating local folders if needed')
-.action(runDownloadSingle);
+        const cb = function () {
+            return new OverwriteAllRemoteWithLocal().run();
+        };
 
-program
-.command('push <filePath>')
-.description('upload local file, creating remote folders if needed')
-.action(runUploadSingle);
+        return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
+    }
+});
+
+// ---- rename ----
 
 program
 .command('rename <oldPath> <newPath>')
-.description('rename remote file or folder, change its parent folder if needed')
-.action(runRename);
+.description('rename or move a remote file or folder')
+.action((oldPath, newPath) => {
+    CUtils.wrapUserErrors(() => {
+        return SCUtils.renameItem(oldPath, newPath);
+    });
+});
+
+// ---- rm ----
 
 program
-.command('rm <filePath>')
-.description('remove remote file or folder')
-.action(runDelete);
+.command('rm <path>')
+.description('remove a remote file or folder')
+.action((filePath) => {
+    CUtils.setForceEnv(filePath);
+
+    CUtils.wrapUserErrors(() => {
+        return SCUtils.deleteItem(filePath);
+    });
+});
+
+// ---- watch ----
 
 program
-.command('parseIgnore')
+.command('watch')
+.description('watch local directory and sync changes to remote in real-time')
+.option('-f, --force', 'skip local/remote equality and multi-instance checks')
+.action(async (cmdObj) => {
+    if (!cmdObj.force) {
+        await CUtils.wrapUserErrors(() => SyncUtils.errorIfDifferent(true));
+
+        await CUtils.wrapUserErrors(SyncUtils.errorIfMultWatch);
+    }
+
+    await startWatcher();
+});
+
+// ---- ignore ----
+
+program
+.command('ignore')
 .description('list assets matched by pcignore.txt')
-.action(runParse);
+.action(() => {
+    CUtils.wrapUserErrors(() => {
+        return SCUtils.reportIgnoredAssets();
+    });
+});
 
-function runCompAll(cmdObj) {
+// ---- init ----
+
+program
+.command('init')
+.description('create a pcconfig.json in the current directory')
+.action(async () => {
+    const { runInit } = await import('../src/commands/init.js');
+    await runInit();
+});
+
+// ---- deprecated commands (hidden from help) ----
+
+function deprecationWarning(oldCmd, newCmd) {
+    console.warn(`Warning: '${oldCmd}' is deprecated. Use '${newCmd}' instead.`);
+}
+
+const diffAllCmd = new Command('diffAll');
+diffAllCmd
+.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'handle files with provided extensions')
+.action((cmdObj) => {
+    deprecationWarning('pcsync diffAll', 'pcsync diff');
     CUtils.handleForceRegOpts(cmdObj);
 
     CUtils.wrapUserErrors(() => {
         return SyncUtils.reportDiffAll();
     });
-}
+});
+program.addCommand(diffAllCmd, { hidden: true });
 
-function runDiff(filePath) {
-    CUtils.wrapUserErrors(() => {
-        return SCUtils.diffSingleFile(filePath);
-    });
-}
-
-function runOverwriteAllLocal(cmdObj) {
+const pullAllCmd = new Command('pullAll');
+pullAllCmd
+.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'handle files with provided extensions')
+.option('-y, --yes', 'Automatically answer "yes" to any prompts.')
+.action((cmdObj) => {
+    deprecationWarning('pcsync pullAll', 'pcsync pull');
     CUtils.handleForceRegOpts(cmdObj);
 
     const cb = function () {
@@ -86,9 +259,16 @@ function runOverwriteAllLocal(cmdObj) {
     };
 
     return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
-}
+});
+program.addCommand(pullAllCmd, { hidden: true });
 
-function runOverwriteAllRemote(cmdObj) {
+const pushAllCmd = new Command('pushAll');
+pushAllCmd
+.option('-r, --regexp <regexp>', 'handle files matching the provided regular expression')
+.option('-e, --ext <extensions>', 'handle files with provided extensions')
+.option('-y, --yes', 'Automatically answer "yes" to any prompts.')
+.action((cmdObj) => {
+    deprecationWarning('pcsync pushAll', 'pcsync push');
     CUtils.handleForceRegOpts(cmdObj);
 
     const cb = function () {
@@ -96,42 +276,215 @@ function runOverwriteAllRemote(cmdObj) {
     };
 
     return cmdObj.yes ? cb() : SyncUtils.compareAndPrompt(cb);
-}
+});
+program.addCommand(pushAllCmd, { hidden: true });
 
-function runDownloadSingle(filePath) {
-    CUtils.setForceEnv(filePath);
+const parseIgnoreCmd = new Command('parseIgnore');
+parseIgnoreCmd
+.action(() => {
+    deprecationWarning('pcsync parseIgnore', 'pcsync ignore');
 
-    CUtils.wrapUserErrors(() => {
-        return SCUtils.downloadSingleFile(filePath);
-    });
-}
-
-function runUploadSingle(filePath) {
-    CUtils.setForceEnv(filePath);
-
-    CUtils.wrapUserErrors(() => {
-        return SCUtils.uploadSingleFile(filePath);
-    });
-}
-
-function runRename(oldPath, newPath) {
-    CUtils.wrapUserErrors(() => {
-        return SCUtils.renameItem(oldPath, newPath);
-    });
-}
-
-function runDelete(filePath) {
-    CUtils.setForceEnv(filePath);
-
-    CUtils.wrapUserErrors(() => {
-        return SCUtils.deleteItem(filePath);
-    });
-}
-
-function runParse() {
     CUtils.wrapUserErrors(() => {
         return SCUtils.reportIgnoredAssets();
     });
+});
+program.addCommand(parseIgnoreCmd, { hidden: true });
+
+// ---- watch helper functions (native fs.watch) ----
+
+async function startWatcher() {
+    const conf = await new GetConfig().run();
+
+    console.log(`Started in ${conf.PLAYCANVAS_TARGET_DIR}`);
+
+    const local = await CacheUtils.getCached(conf, 'local_items');
+
+    const pathToData = local.locPathToData;
+
+    const debounceTimers = {};
+
+    const watcher = fs.watch(
+        conf.PLAYCANVAS_TARGET_DIR,
+        { recursive: true },
+        (eventType, filename) => {
+            if (!filename) return;
+
+            // Normalize path separators to OS-native format
+            const relativePath = filename.replace(/[\\/]/g, path.sep);
+            const fullPath = path.join(conf.PLAYCANVAS_TARGET_DIR, relativePath);
+
+            // Debounce: reset timer for this path on every event
+            if (debounceTimers[fullPath]) {
+                clearTimeout(debounceTimers[fullPath]);
+            }
+
+            debounceTimers[fullPath] = setTimeout(() => {
+                delete debounceTimers[fullPath];
+                processChange(fullPath, conf, pathToData);
+            }, WatchUtils.DEBOUNCE_MS);
+        }
+    );
+
+    // Keep process alive and handle clean shutdown
+    process.on('SIGINT', () => {
+        watcher.close();
+        process.exit(0);
+    });
+
+    process.on('SIGTERM', () => {
+        watcher.close();
+        process.exit(0);
+    });
 }
 
-program.parse(process.argv);
+async function processChange(fullPath, conf, pathToData) {
+    const rootDir = conf.PLAYCANVAS_TARGET_DIR;
+
+    // Build the relative path parts from the full path
+    const relative = path.relative(rootDir, fullPath);
+    const pathAr = relative.split(path.sep);
+    const remotePath = PathUtils.arToSlashForwPath(pathAr);
+    const itemName = pathAr[pathAr.length - 1];
+
+    const parentAr = pathAr.slice(0, pathAr.length - 1);
+    const parentFull = PathUtils.pathArToFullLocal(rootDir, parentAr);
+    const parentRemote = PathUtils.arToSlashForwPath(parentAr);
+
+    // Stat the file to determine if it exists and what type it is
+    const stat = await PathUtils.fsWrap('stat', fullPath);
+
+    if (!stat) {
+        // File/directory no longer exists -- it was deleted
+        await handleDeletion(fullPath, pathToData, conf);
+        return;
+    }
+
+    const itemData = {
+        itemName,
+        fullPath,
+        remotePath,
+        isFile: stat.isFile(),
+        isDirectory: stat.isDirectory(),
+        modTime: stat.mtime.getTime(),
+        hash: null,
+        pathArray: pathAr,
+        parentFull,
+        parentRemote
+    };
+
+    const cached = pathToData[fullPath];
+
+    if (stat.isFile()) {
+        if (cached) {
+            await handleKnownFile(itemData, cached, pathToData, conf);
+        } else {
+            await handleCreatedFile(itemData, pathToData, conf);
+        }
+    } else if (stat.isDirectory()) {
+        if (!cached) {
+            // New directory
+            pathToData[fullPath] = itemData;
+            await triggerEvent('ACTION_CREATED', itemData, conf);
+        }
+    }
+}
+
+async function handleKnownFile(itemData, cached, pathToData, conf) {
+    // If the hash was not yet computed, compute it now.
+    // If modTime also changed, the file was modified before we had a
+    // baseline hash, so trigger the sync event immediately.
+    if (!cached.hash) {
+        itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
+        pathToData[itemData.fullPath] = itemData;
+
+        if (itemData.modTime !== cached.modTime) {
+            await triggerEvent('ACTION_MODIFIED', itemData, conf);
+        }
+        return;
+    }
+
+    // Only recalculate hash if the modification time changed
+    if (itemData.modTime !== cached.modTime) {
+        itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
+
+        if (itemData.hash !== cached.hash) {
+            pathToData[itemData.fullPath] = itemData;
+            await triggerEvent('ACTION_MODIFIED', itemData, conf);
+        } else {
+            pathToData[itemData.fullPath] = itemData;
+        }
+    } else {
+        itemData.hash = cached.hash;
+        pathToData[itemData.fullPath] = itemData;
+    }
+}
+
+async function handleCreatedFile(itemData, pathToData, conf) {
+    itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
+    pathToData[itemData.fullPath] = itemData;
+    await triggerEvent('ACTION_CREATED', itemData, conf);
+}
+
+async function handleDeletion(fullPath, pathToData, conf) {
+    // Collect all cached paths that are under the deleted path (or the path itself)
+    const deleted = Object.keys(pathToData).filter((p) => {
+        return p === fullPath || p.startsWith(fullPath + path.sep);
+    });
+
+    // Sort children before parents (longest paths first)
+    deleted.sort((a, b) => b.length - a.length);
+
+    for (const p of deleted) {
+        const data = pathToData[p];
+        delete pathToData[p];
+        await triggerEvent('ACTION_DELETED', data, conf);
+    }
+}
+
+async function triggerEvent(action, itemData, conf) {
+    const event = { action };
+    Object.assign(event, itemData);
+    await handleEvent(event, conf);
+}
+
+async function handleEvent(e, conf) {
+    if (WatchUtils.shouldKeepEvent(e, conf) && !conf.PLAYCANVAS_DRY_RUN) {
+        return await handleGoodEvent(e, conf);
+    }
+}
+
+async function handleGoodEvent(e, conf) {
+    if (e.action === 'ACTION_MODIFIED') {
+        await eventModified(e, conf);
+
+    } else if (e.action === 'ACTION_DELETED') {
+        const deleted = await WatchUtils.actionDeleted(e.remotePath, conf);
+
+        if (deleted) {
+            console.log(`Deleted ${e.remotePath}`);
+        } else {
+            console.log(`Skipped deletion of remote folder ${e.remotePath} (contains unsynced assets)`);
+        }
+
+    } else if (e.action === 'ACTION_CREATED') {
+        await eventCreated(e, conf);
+    }
+}
+
+async function eventModified(e, conf) {
+    if (CUtils.eventHasAsset(e, conf)) {
+        const id = await WatchUtils.actionModified(e, conf);
+
+        WatchUtils.reportWatchAction(id, 'Updated', conf);
+    }
+}
+
+async function eventCreated(e, conf) {
+    if (!CUtils.eventHasAsset(e, conf)) {
+        const id = await new ActionCreated(e, conf).run();
+
+        WatchUtils.reportWatchAction(id, 'Created', conf);
+    }
+}
+
+program.parse(preprocessArgs(process.argv));

--- a/bin/pcwatch.js
+++ b/bin/pcwatch.js
@@ -1,227 +1,28 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
+/**
+ * Deprecated: use 'pcsync watch' instead.
+ *
+ * This wrapper forwards all arguments to 'pcsync watch' and will be
+ * removed in a future major version.
+ */
 
-import { Command } from 'commander';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 
-import SyncUtils from '../src/sync-commands/sync-utils.js';
-import CacheUtils from '../src/utils/cache-utils.js';
-import CUtils from '../src/utils/common-utils.js';
-import GetConfig from '../src/utils/get-config.js';
-import PathUtils from '../src/utils/path-utils.js';
-import ActionCreated from '../src/watch-actions/action-created.js';
-import WatchUtils from '../src/watch-actions/watch-utils.js';
+console.warn('Warning: \'pcwatch\' is deprecated. Use \'pcsync watch\' instead.');
 
-const program = new Command();
+const pcsyncBin = fileURLToPath(new URL('./pcsync.js', import.meta.url));
 
-program.option('-f, --force', 'skip local/remote equality check');
+// Forward all arguments to 'pcsync watch'
+const args = ['watch', ...process.argv.slice(2)];
 
-program.parse(process.argv);
-
-async function run() {
-    if (!program.opts().force) {
-        await CUtils.wrapUserErrors(() => SyncUtils.errorIfDifferent(true));
-
-        await CUtils.wrapUserErrors(SyncUtils.errorIfMultWatch);
-    }
-
-    await startWatcher();
-}
-
-async function startWatcher() {
-    const conf = await new GetConfig().run();
-
-    console.log(`Started in ${conf.PLAYCANVAS_TARGET_DIR}`);
-
-    const local = await CacheUtils.getCached(conf, 'local_items');
-
-    const pathToData = local.locPathToData;
-
-    const debounceTimers = {};
-
-    const watcher = fs.watch(
-        conf.PLAYCANVAS_TARGET_DIR,
-        { recursive: true },
-        (eventType, filename) => {
-            if (!filename) return;
-
-            // Normalize path separators to OS-native format
-            const relativePath = filename.replace(/[\\/]/g, path.sep);
-            const fullPath = path.join(conf.PLAYCANVAS_TARGET_DIR, relativePath);
-
-            // Debounce: reset timer for this path on every event
-            if (debounceTimers[fullPath]) {
-                clearTimeout(debounceTimers[fullPath]);
-            }
-
-            debounceTimers[fullPath] = setTimeout(() => {
-                delete debounceTimers[fullPath];
-                processChange(fullPath, conf, pathToData);
-            }, WatchUtils.DEBOUNCE_MS);
-        }
-    );
-
-    // Keep process alive and handle clean shutdown
-    process.on('SIGINT', () => {
-        watcher.close();
-        process.exit(0);
+try {
+    execFileSync(process.execPath, [pcsyncBin, ...args], {
+        stdio: 'inherit'
     });
-
-    process.on('SIGTERM', () => {
-        watcher.close();
-        process.exit(0);
-    });
+} catch (e) {
+    // execFileSync throws on non-zero exit; the child's output was
+    // already printed via stdio: 'inherit', so just propagate the code.
+    process.exit(e.status ?? 1);
 }
-
-async function processChange(fullPath, conf, pathToData) {
-    const rootDir = conf.PLAYCANVAS_TARGET_DIR;
-
-    // Build the relative path parts from the full path
-    const relative = path.relative(rootDir, fullPath);
-    const pathAr = relative.split(path.sep);
-    const remotePath = PathUtils.arToSlashForwPath(pathAr);
-    const itemName = pathAr[pathAr.length - 1];
-
-    const parentAr = pathAr.slice(0, pathAr.length - 1);
-    const parentFull = PathUtils.pathArToFullLocal(rootDir, parentAr);
-    const parentRemote = PathUtils.arToSlashForwPath(parentAr);
-
-    // Stat the file to determine if it exists and what type it is
-    const stat = await PathUtils.fsWrap('stat', fullPath);
-
-    if (!stat) {
-        // File/directory no longer exists -- it was deleted
-        await handleDeletion(fullPath, pathToData, conf);
-        return;
-    }
-
-    const itemData = {
-        itemName,
-        fullPath,
-        remotePath,
-        isFile: stat.isFile(),
-        isDirectory: stat.isDirectory(),
-        modTime: stat.mtime.getTime(),
-        hash: null,
-        pathArray: pathAr,
-        parentFull,
-        parentRemote
-    };
-
-    const cached = pathToData[fullPath];
-
-    if (stat.isFile()) {
-        if (cached) {
-            await handleKnownFile(itemData, cached, pathToData, conf);
-        } else {
-            await handleCreatedFile(itemData, pathToData, conf);
-        }
-    } else if (stat.isDirectory()) {
-        if (!cached) {
-            // New directory
-            pathToData[fullPath] = itemData;
-            await triggerEvent('ACTION_CREATED', itemData, conf);
-        }
-    }
-}
-
-async function handleKnownFile(itemData, cached, pathToData, conf) {
-    // If the hash was not yet computed, compute it now.
-    // If modTime also changed, the file was modified before we had a
-    // baseline hash, so trigger the sync event immediately.
-    if (!cached.hash) {
-        itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
-        pathToData[itemData.fullPath] = itemData;
-
-        if (itemData.modTime !== cached.modTime) {
-            await triggerEvent('ACTION_MODIFIED', itemData, conf);
-        }
-        return;
-    }
-
-    // Only recalculate hash if the modification time changed
-    if (itemData.modTime !== cached.modTime) {
-        itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
-
-        if (itemData.hash !== cached.hash) {
-            pathToData[itemData.fullPath] = itemData;
-            await triggerEvent('ACTION_MODIFIED', itemData, conf);
-        } else {
-            pathToData[itemData.fullPath] = itemData;
-        }
-    } else {
-        itemData.hash = cached.hash;
-        pathToData[itemData.fullPath] = itemData;
-    }
-}
-
-async function handleCreatedFile(itemData, pathToData, conf) {
-    itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
-    pathToData[itemData.fullPath] = itemData;
-    await triggerEvent('ACTION_CREATED', itemData, conf);
-}
-
-async function handleDeletion(fullPath, pathToData, conf) {
-    // Collect all cached paths that are under the deleted path (or the path itself)
-    const deleted = Object.keys(pathToData).filter((p) => {
-        return p === fullPath || p.startsWith(fullPath + path.sep);
-    });
-
-    // Sort children before parents (longest paths first)
-    deleted.sort((a, b) => b.length - a.length);
-
-    for (const p of deleted) {
-        const data = pathToData[p];
-        delete pathToData[p];
-        await triggerEvent('ACTION_DELETED', data, conf);
-    }
-}
-
-async function triggerEvent(action, itemData, conf) {
-    const event = { action };
-    Object.assign(event, itemData);
-    await handleEvent(event, conf);
-}
-
-async function handleEvent(e, conf) {
-    if (WatchUtils.shouldKeepEvent(e, conf) && !conf.PLAYCANVAS_DRY_RUN) {
-        return await handleGoodEvent(e, conf);
-    }
-}
-
-async function handleGoodEvent(e, conf) {
-    if (e.action === 'ACTION_MODIFIED') {
-        await eventModified(e, conf);
-
-    } else if (e.action === 'ACTION_DELETED') {
-        const deleted = await WatchUtils.actionDeleted(e.remotePath, conf);
-
-        if (deleted) {
-            console.log(`Deleted ${e.remotePath}`);
-        } else {
-            console.log(`Skipped deletion of remote folder ${e.remotePath} (contains unsynced assets)`);
-        }
-
-    } else if (e.action === 'ACTION_CREATED') {
-        await eventCreated(e, conf);
-    }
-}
-
-async function eventModified(e, conf) {
-    if (CUtils.eventHasAsset(e, conf)) {
-        const id = await WatchUtils.actionModified(e, conf);
-
-        WatchUtils.reportWatchAction(id, 'Updated', conf);
-    }
-}
-
-async function eventCreated(e, conf) {
-    if (!CUtils.eventHasAsset(e, conf)) {
-        const id = await new ActionCreated(e, conf).run();
-
-        WatchUtils.reportWatchAction(id, 'Created', conf);
-    }
-}
-
-run();

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+const CONFIG_FILE = 'pcconfig.json';
+
+function question(rl, prompt) {
+    return new Promise((resolve) => {
+        rl.question(prompt, (answer) => {
+            resolve(answer.trim());
+        });
+    });
+}
+
+async function runInit() {
+    const configPath = path.join(process.cwd(), CONFIG_FILE);
+
+    if (fs.existsSync(configPath)) {
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+
+        const answer = await question(rl, `${CONFIG_FILE} already exists. Overwrite? [y/n] `);
+        rl.close();
+
+        if (answer !== 'y') {
+            console.log('Aborted.');
+            return;
+        }
+    }
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    console.log('Setting up PlayCanvas sync configuration...\n');
+
+    const apiKey = await question(rl, 'PlayCanvas API key: ');
+    const projectId = await question(rl, 'PlayCanvas project ID: ');
+    const branchId = await question(rl, 'PlayCanvas branch ID: ');
+    const targetDir = await question(rl, `Target directory [${process.cwd()}]: `);
+
+    rl.close();
+
+    const config = {
+        PLAYCANVAS_API_KEY: apiKey,
+        PLAYCANVAS_PROJECT_ID: parseInt(projectId, 10) || projectId,
+        PLAYCANVAS_BRANCH_ID: branchId,
+        PLAYCANVAS_TARGET_DIR: targetDir || process.cwd(),
+        PLAYCANVAS_BAD_FILE_REG: '^\\.|~$',
+        PLAYCANVAS_BAD_FOLDER_REG: '\\.',
+        PLAYCANVAS_CONVERT_TO_POW2: 0
+    };
+
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    console.log(`\nCreated ${configPath}`);
+}
+
+export { runInit };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -44,11 +44,15 @@ async function runInit() {
 
     rl.close();
 
+    const parsedProjectId = parseInt(projectId, 10);
+    const playcanvasProjectId = Number.isNaN(parsedProjectId) ? projectId : parsedProjectId;
+    const resolvedTargetDir = targetDir === '' ? process.cwd() : targetDir;
+
     const config = {
         PLAYCANVAS_API_KEY: apiKey,
-        PLAYCANVAS_PROJECT_ID: parseInt(projectId, 10) || projectId,
+        PLAYCANVAS_PROJECT_ID: playcanvasProjectId,
         PLAYCANVAS_BRANCH_ID: branchId,
-        PLAYCANVAS_TARGET_DIR: targetDir || process.cwd(),
+        PLAYCANVAS_TARGET_DIR: resolvedTargetDir,
         PLAYCANVAS_BAD_FILE_REG: '^\\.|~$',
         PLAYCANVAS_BAD_FOLDER_REG: '\\.',
         PLAYCANVAS_CONVERT_TO_POW2: 0

--- a/src/sync-commands/sync-utils.js
+++ b/src/sync-commands/sync-utils.js
@@ -97,7 +97,7 @@ const SyncUtils = {
         const a = await SyncUtils.getWatchProcs();
 
         if (a.length > 1) { // 1 (this process) is expected
-            const s = `Other running instances of 'pcwatch' detected. Stop them${
+            const s = `Other running watch instances detected. Stop them${
                 SyncUtils.forceMsg(true)}`;
 
             CUtils.throwFtError(s);
@@ -107,7 +107,8 @@ const SyncUtils = {
     getWatchProcs: async function () {
         const conf = await new GetConfig().run();
 
-        const a = await FindProcess('name', /pcwatch/);
+        // detect both legacy 'pcwatch' and new 'pcsync watch' processes
+        const a = await FindProcess('name', /pcsync|pcwatch/);
 
         if (conf.PLAYCANVAS_VERBOSE) {
             console.log(a);

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -49,32 +49,6 @@ const regexFields = [
 ];
 
 class ConfigVars {
-    /**
-     * Apply CLI option overrides as environment variables so they take
-     * highest priority when config is loaded. Call before constructing
-     * or running ConfigVars.
-     *
-     * @param {object} opts - Parsed Commander global options.
-     */
-    static applyCliOverrides(opts) {
-        const mapping = {
-            apiKey: 'PLAYCANVAS_API_KEY',
-            projectId: 'PLAYCANVAS_PROJECT_ID',
-            branchId: 'PLAYCANVAS_BRANCH_ID',
-            targetDir: 'PLAYCANVAS_TARGET_DIR',
-            baseUrl: 'PLAYCANVAS_BASE_URL'
-        };
-
-        for (const [opt, envVar] of Object.entries(mapping)) {
-            if (opts[opt]) {
-                process.env[envVar] = opts[opt];
-            }
-        }
-
-        if (opts.dryRun) process.env.PLAYCANVAS_DRY_RUN = '1';
-        if (opts.verbose) process.env.PLAYCANVAS_VERBOSE = '1';
-    }
-
     constructor() {
         this.result = {};
     }

--- a/src/utils/config-vars.js
+++ b/src/utils/config-vars.js
@@ -49,6 +49,32 @@ const regexFields = [
 ];
 
 class ConfigVars {
+    /**
+     * Apply CLI option overrides as environment variables so they take
+     * highest priority when config is loaded. Call before constructing
+     * or running ConfigVars.
+     *
+     * @param {object} opts - Parsed Commander global options.
+     */
+    static applyCliOverrides(opts) {
+        const mapping = {
+            apiKey: 'PLAYCANVAS_API_KEY',
+            projectId: 'PLAYCANVAS_PROJECT_ID',
+            branchId: 'PLAYCANVAS_BRANCH_ID',
+            targetDir: 'PLAYCANVAS_TARGET_DIR',
+            baseUrl: 'PLAYCANVAS_BASE_URL'
+        };
+
+        for (const [opt, envVar] of Object.entries(mapping)) {
+            if (opts[opt]) {
+                process.env[envVar] = opts[opt];
+            }
+        }
+
+        if (opts.dryRun) process.env.PLAYCANVAS_DRY_RUN = '1';
+        if (opts.verbose) process.env.PLAYCANVAS_VERBOSE = '1';
+    }
+
     constructor() {
         this.result = {};
     }

--- a/test/unit/common-utils.test.js
+++ b/test/unit/common-utils.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { stub } from 'sinon';
 import CUtils from '../../src/utils/common-utils.js';
 
 describe('CUtils', function () {
@@ -454,7 +454,7 @@ describe('CUtils', function () {
         let exitStub;
 
         beforeEach(function () {
-            exitStub = sinon.stub(process, 'exit');
+            exitStub = stub(process, 'exit');
         });
 
         afterEach(function () {

--- a/test/unit/init.test.js
+++ b/test/unit/init.test.js
@@ -7,8 +7,6 @@ import { runInit } from '../../src/commands/init.js';
 describe('init command', function () {
     let fsExistsStub;
     let fsWriteStub;
-    let cwdStub;
-    let rlStub;
     let consoleLogStub;
 
     // Helper to create a mock readline interface
@@ -25,7 +23,7 @@ describe('init command', function () {
     beforeEach(function () {
         fsExistsStub = sinon.stub(fs, 'existsSync');
         fsWriteStub = sinon.stub(fs, 'writeFileSync');
-        cwdStub = sinon.stub(process, 'cwd').returns('/test/dir');
+        sinon.stub(process, 'cwd').returns('/test/dir');
         consoleLogStub = sinon.stub(console, 'log');
     });
 
@@ -38,7 +36,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['test-api-key', '12345', 'branch-uuid', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -59,7 +57,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '999', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -72,7 +70,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', 'not-a-number', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -84,7 +82,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -96,7 +94,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -117,7 +115,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+            sinon.stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -134,7 +132,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+            sinon.stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -151,7 +149,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+            sinon.stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -173,7 +171,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+            sinon.stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -191,7 +189,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+            sinon.stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -205,7 +203,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -217,7 +215,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', '/custom/path'];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -229,7 +227,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['  key  ', '  123  ', '  branch  ', '  /path  '];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -244,7 +242,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['', '123', 'branch', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -256,7 +254,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', '', ''];
-            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 

--- a/test/unit/init.test.js
+++ b/test/unit/init.test.js
@@ -1,0 +1,267 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'fs';
+import readline from 'readline';
+import { runInit } from '../../src/commands/init.js';
+
+describe('init command', function () {
+    let fsExistsStub;
+    let fsWriteStub;
+    let cwdStub;
+    let rlStub;
+    let consoleLogStub;
+
+    // Helper to create a mock readline interface
+    function createMockReadline(answers) {
+        let answerIndex = 0;
+        return {
+            question: (prompt, callback) => {
+                callback(answers[answerIndex++] || '');
+            },
+            close: () => {}
+        };
+    }
+
+    beforeEach(function () {
+        fsExistsStub = sinon.stub(fs, 'existsSync');
+        fsWriteStub = sinon.stub(fs, 'writeFileSync');
+        cwdStub = sinon.stub(process, 'cwd').returns('/test/dir');
+        consoleLogStub = sinon.stub(console, 'log');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('generated JSON shape', function () {
+        it('should create config with all required fields', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['test-api-key', '12345', 'branch-uuid', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            expect(fsWriteStub.calledOnce).to.be.true;
+            const writtenContent = fsWriteStub.firstCall.args[1];
+            const config = JSON.parse(writtenContent);
+
+            expect(config).to.have.property('PLAYCANVAS_API_KEY', 'test-api-key');
+            expect(config).to.have.property('PLAYCANVAS_PROJECT_ID', 12345);
+            expect(config).to.have.property('PLAYCANVAS_BRANCH_ID', 'branch-uuid');
+            expect(config).to.have.property('PLAYCANVAS_TARGET_DIR', '/test/dir');
+            expect(config).to.have.property('PLAYCANVAS_BAD_FILE_REG', '^\\.|~$');
+            expect(config).to.have.property('PLAYCANVAS_BAD_FOLDER_REG', '\\.');
+            expect(config).to.have.property('PLAYCANVAS_CONVERT_TO_POW2', 0);
+        });
+
+        it('should parse numeric project ID as integer', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '999', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_PROJECT_ID).to.equal(999);
+            expect(typeof config.PLAYCANVAS_PROJECT_ID).to.equal('number');
+        });
+
+        it('should keep non-numeric project ID as string', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', 'not-a-number', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_PROJECT_ID).to.equal('not-a-number');
+        });
+
+        it('should write config file with trailing newline', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '123', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const writtenContent = fsWriteStub.firstCall.args[1];
+            expect(writtenContent.endsWith('\n')).to.be.true;
+        });
+
+        it('should write to pcconfig.json in current directory', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '123', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const writtenPath = fsWriteStub.firstCall.args[0];
+            expect(writtenPath).to.include('pcconfig.json');
+        });
+    });
+
+    describe('overwrite prompt behavior', function () {
+        it('should prompt when config already exists', async function () {
+            fsExistsStub.returns(true);
+
+            const questions = [];
+            const mockRl = {
+                question: (prompt, callback) => {
+                    questions.push(prompt);
+                    callback('n'); // Decline overwrite
+                },
+                close: () => {}
+            };
+            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+
+            await runInit();
+
+            expect(questions[0]).to.include('already exists');
+            expect(questions[0]).to.include('Overwrite');
+        });
+
+        it('should abort when user declines overwrite', async function () {
+            fsExistsStub.returns(true);
+
+            const mockRl = {
+                question: (prompt, callback) => {
+                    callback('n');
+                },
+                close: () => {}
+            };
+            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+
+            await runInit();
+
+            expect(fsWriteStub.called).to.be.false;
+            expect(consoleLogStub.calledWith('Aborted.')).to.be.true;
+        });
+
+        it('should abort when user enters anything other than y', async function () {
+            fsExistsStub.returns(true);
+
+            const mockRl = {
+                question: (prompt, callback) => {
+                    callback('yes'); // 'yes' is not 'y'
+                },
+                close: () => {}
+            };
+            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+
+            await runInit();
+
+            expect(fsWriteStub.called).to.be.false;
+        });
+
+        it('should proceed when user confirms with y', async function () {
+            fsExistsStub.returns(true);
+
+            let questionCount = 0;
+            const mockRl = {
+                question: (prompt, callback) => {
+                    questionCount++;
+                    if (questionCount === 1) {
+                        callback('y'); // Confirm overwrite
+                    } else {
+                        callback('test-value');
+                    }
+                },
+                close: () => {}
+            };
+            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+
+            await runInit();
+
+            expect(fsWriteStub.called).to.be.true;
+        });
+
+        it('should not prompt when config does not exist', async function () {
+            fsExistsStub.returns(false);
+
+            const questions = [];
+            const mockRl = {
+                question: (prompt, callback) => {
+                    questions.push(prompt);
+                    callback('value');
+                },
+                close: () => {}
+            };
+            rlStub = sinon.stub(readline, 'createInterface').returns(mockRl);
+
+            await runInit();
+
+            expect(questions[0]).to.not.include('Overwrite');
+            expect(questions[0]).to.include('API key');
+        });
+    });
+
+    describe('handling blank inputs', function () {
+        it('should use cwd as default when target directory is blank', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '123', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_TARGET_DIR).to.equal('/test/dir');
+        });
+
+        it('should use provided target directory when specified', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '123', 'branch', '/custom/path'];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_TARGET_DIR).to.equal('/custom/path');
+        });
+
+        it('should trim whitespace from all inputs', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['  key  ', '  123  ', '  branch  ', '  /path  '];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_API_KEY).to.equal('key');
+            expect(config.PLAYCANVAS_PROJECT_ID).to.equal(123);
+            expect(config.PLAYCANVAS_BRANCH_ID).to.equal('branch');
+            expect(config.PLAYCANVAS_TARGET_DIR).to.equal('/path');
+        });
+
+        it('should store empty string for blank API key', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['', '123', 'branch', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_API_KEY).to.equal('');
+        });
+
+        it('should store empty string for blank branch ID', async function () {
+            fsExistsStub.returns(false);
+
+            const answers = ['key', '123', '', ''];
+            rlStub = sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+
+            await runInit();
+
+            const config = JSON.parse(fsWriteStub.firstCall.args[1]);
+            expect(config.PLAYCANVAS_BRANCH_ID).to.equal('');
+        });
+    });
+});

--- a/test/unit/init.test.js
+++ b/test/unit/init.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { stub, restore } from 'sinon';
 import fs from 'fs';
 import readline from 'readline';
 import { runInit } from '../../src/commands/init.js';
@@ -21,14 +21,14 @@ describe('init command', function () {
     }
 
     beforeEach(function () {
-        fsExistsStub = sinon.stub(fs, 'existsSync');
-        fsWriteStub = sinon.stub(fs, 'writeFileSync');
-        sinon.stub(process, 'cwd').returns('/test/dir');
-        consoleLogStub = sinon.stub(console, 'log');
+        fsExistsStub = stub(fs, 'existsSync');
+        fsWriteStub = stub(fs, 'writeFileSync');
+        stub(process, 'cwd').returns('/test/dir');
+        consoleLogStub = stub(console, 'log');
     });
 
     afterEach(function () {
-        sinon.restore();
+        restore();
     });
 
     describe('generated JSON shape', function () {
@@ -36,7 +36,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['test-api-key', '12345', 'branch-uuid', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -57,7 +57,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '999', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -70,7 +70,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', 'not-a-number', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -82,7 +82,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -94,7 +94,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -115,7 +115,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            sinon.stub(readline, 'createInterface').returns(mockRl);
+            stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -132,7 +132,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            sinon.stub(readline, 'createInterface').returns(mockRl);
+            stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -149,7 +149,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            sinon.stub(readline, 'createInterface').returns(mockRl);
+            stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -171,7 +171,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            sinon.stub(readline, 'createInterface').returns(mockRl);
+            stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -189,7 +189,7 @@ describe('init command', function () {
                 },
                 close: () => {}
             };
-            sinon.stub(readline, 'createInterface').returns(mockRl);
+            stub(readline, 'createInterface').returns(mockRl);
 
             await runInit();
 
@@ -203,7 +203,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -215,7 +215,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', 'branch', '/custom/path'];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -227,7 +227,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['  key  ', '  123  ', '  branch  ', '  /path  '];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -242,7 +242,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['', '123', 'branch', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 
@@ -254,7 +254,7 @@ describe('init command', function () {
             fsExistsStub.returns(false);
 
             const answers = ['key', '123', '', ''];
-            sinon.stub(readline, 'createInterface').returns(createMockReadline(answers));
+            stub(readline, 'createInterface').returns(createMockReadline(answers));
 
             await runInit();
 


### PR DESCRIPTION
## Summary

Modernizes the CLI interface to be more intuitive and consistent with standard CLI conventions (`git`, `npm`, etc.).

- Merge single/all command variants into unified commands with an optional file argument: `diff [file]`, `pull [file]`, `push [file]`
- Absorb `pcwatch` into `pcsync watch` subcommand (single binary, single help system)
- Rename `parseIgnore` to `ignore`
- Add `init` interactive setup wizard for `pcconfig.json`
- Add global CLI options: `--version`, `--dry-run`, `--verbose`, `--api-key`, `--project-id`, `--branch-id`, `--target-dir`, `--base-url`
- Old commands (`diffAll`, `pullAll`, `pushAll`, `parseIgnore`) and `pcwatch` binary remain as deprecated aliases with warnings

### Migration table

| v2 | v3 |
|---|---|
| `pcsync diffAll` | `pcsync diff` |
| `pcsync pullAll` | `pcsync pull` |
| `pcsync pushAll` | `pcsync push` |
| `pcsync parseIgnore` | `pcsync ignore` |
| `pcwatch [-f]` | `pcsync watch [--force]` |

Closes #73

## Test plan

- [x] All 277 existing tests pass
- [x] All files pass ESLint
- [x] Verify `pcsync --help` shows new command structure
- [x] Verify `pcsync --version` prints version
- [x] Verify `pcsync diff`, `pcsync pull`, `pcsync push` work without file arg (bulk mode)
- [x] Verify `pcsync diff <file>`, `pcsync pull <file>`, `pcsync push <file>` work (single file mode)
- [x] Verify `pcsync watch` starts the watcher
- [x] Verify `pcsync init` prompts and creates `pcconfig.json`
- [x] Verify `pcsync ignore` lists matched assets
- [x] Verify deprecated commands (`diffAll`, `pullAll`, etc.) still work but print warnings
- [x] Verify `pcwatch` prints deprecation warning and delegates to `pcsync watch`
- [x] Verify `--dry-run` and `--verbose` flags work as global options
