### PR TITLE
fix: sync first file edit when watcher starts with null hashes

### DIFF
--- a/bin/pcwatch.js
+++ b/bin/pcwatch.js
@@ -127,10 +127,16 @@ async function processChange(fullPath, conf, pathToData) {
 }
 
 async function handleKnownFile(itemData, cached, pathToData, conf) {
-    // If the hash was not yet computed, compute it for future comparisons
+    // If the hash was not yet computed, compute it now.
+    // If modTime also changed, the file was modified before we had a
+    // baseline hash, so trigger the sync event immediately.
     if (!cached.hash) {
         itemData.hash = await CUtils.fileToMd5Hash(itemData.fullPath);
         pathToData[itemData.fullPath] = itemData;
+
+        if (itemData.modTime !== cached.modTime) {
+            await triggerEvent('ACTION_MODIFIED', itemData, conf);
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where the first file edit after starting `pcwatch` was silently dropped

## Problem

PR #97 replaced the polling watcher with native `fs.watch`. The initial local scan creates cached file entries with `hash: null` (computing hashes for all files upfront would be expensive). 

When `fs.watch` detected a file change, `handleKnownFile()` would:
1. See that `cached.hash` is null
2. Compute the hash
3. Return early **without** triggering `ACTION_MODIFIED`

This meant the first edit to any file after the watcher started was silently dropped. Only the second edit would sync.

## Fix

When `cached.hash` is null and `modTime` has changed, we now trigger the sync event immediately after computing the hash.

## Test plan

1. Start `pcwatch` in a synced directory
2. Edit any file
3. Verify the edit syncs to the server immediately (previously it wouldn't until the second edit)
